### PR TITLE
rebrand to @instructure/i18nliner-handlebars

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [ ["@babel/env", { "modules": "cjs" }] ]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,9 +3,9 @@
     "browser": true,
     "node": true
   },
-  parserOptions: {
-    ecmaVersion: 6,
-    sourceType: "module",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
   },
   "rules": {
     "indent": ["error", 2, { "SwitchCase": 1 }],

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-before_script: 'npm install -g grunt-cli'
 language: node_js
 node_js:
   - "10"
   - "12"
+script:
+  - npm run lint
+  - npm test

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2015 Stanley Stuart, Jon Jensen
+Copyright (c) 2013-2020 Stanley Stuart, Jon Jensen, Ahmad Amireh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/dist/lib/errors.js
+++ b/dist/lib/errors.js
@@ -1,17 +1,19 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports["default"] = void 0;
 
-var _errors = require('i18nliner/dist/lib/errors');
+var _errors = _interopRequireDefault(require("i18nliner/dist/lib/errors"));
 
-var _errors2 = _interopRequireDefault(_errors);
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+_errors["default"].register('TBlockNestingError');
 
-_errors2.default.register('TBlockNestingError');
-_errors2.default.register('UnwrappableContentError');
-_errors2.default.register('MultipleSubExpressionsError');
+_errors["default"].register('UnwrappableContentError');
 
-exports.default = _errors2.default;
+_errors["default"].register('MultipleSubExpressionsError');
+
+var _default = _errors["default"];
+exports["default"] = _default;

--- a/dist/lib/extractor.js
+++ b/dist/lib/extractor.js
@@ -3,16 +3,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports["default"] = void 0;
 
-var _t_call = require("./t_call");
+var _t_call = _interopRequireDefault(require("./t_call"));
 
-var _t_call2 = _interopRequireDefault(_t_call);
+var _visitor = _interopRequireDefault(require("./visitor"));
 
-var _visitor = require("./visitor");
-
-var _visitor2 = _interopRequireDefault(_visitor);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function Extractor(ast, options) {
   options = options || {};
@@ -20,7 +17,7 @@ function Extractor(ast, options) {
   this.helperKey = options.helperKey || 't';
 }
 
-Extractor.prototype = Object.create(_visitor2.default);
+Extractor.prototype = Object.create(_visitor["default"]);
 
 Extractor.prototype.forEach = function (handler) {
   this.handler = handler;
@@ -28,14 +25,15 @@ Extractor.prototype.forEach = function (handler) {
 };
 
 Extractor.prototype.processSexpr = function (sexpr) {
-  _visitor2.default.processSexpr.call(this, sexpr);
+  _visitor["default"].processSexpr.call(this, sexpr);
+
   if (sexpr.id.string === this.helperKey) {
     this.processTranslateCall(sexpr);
   }
 };
 
 Extractor.prototype.buildTranslateCall = function (sexpr) {
-  return new _t_call2.default(sexpr);
+  return new _t_call["default"](sexpr);
 };
 
 Extractor.prototype.processTranslateCall = function (sexpr) {
@@ -44,10 +42,12 @@ Extractor.prototype.processTranslateCall = function (sexpr) {
       translation,
       i,
       len;
+
   for (i = 0, len = translations.length; i < len; i++) {
     translation = translations[i];
     this.handler(translation[0], translation[1], call);
   }
 };
 
-exports.default = Extractor;
+var _default = Extractor;
+exports["default"] = _default;

--- a/dist/lib/hbs_processor.js
+++ b/dist/lib/hbs_processor.js
@@ -3,41 +3,33 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports["default"] = void 0;
 
-var _fs = require("fs");
+var _fs = _interopRequireDefault(require("fs"));
 
-var _fs2 = _interopRequireDefault(_fs);
+var _handlebars = _interopRequireDefault(require("handlebars"));
 
-var _handlebars = require("handlebars");
+var _abstract_processor = _interopRequireDefault(require("i18nliner/dist/lib/processors/abstract_processor"));
 
-var _handlebars2 = _interopRequireDefault(_handlebars);
+var _pre_processor = _interopRequireDefault(require("./pre_processor"));
 
-var _abstract_processor = require("i18nliner/dist/lib/processors/abstract_processor");
+var _extractor = _interopRequireDefault(require("./extractor"));
 
-var _abstract_processor2 = _interopRequireDefault(_abstract_processor);
-
-var _pre_processor = require("./pre_processor");
-
-var _pre_processor2 = _interopRequireDefault(_pre_processor);
-
-var _extractor = require("./extractor");
-
-var _extractor2 = _interopRequireDefault(_extractor);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 var HbsProcessor = function HbsProcessor(translations, options) {
-  _abstract_processor2.default.call(this, translations, options);
+  _abstract_processor["default"].call(this, translations, options);
 };
 
-HbsProcessor.prototype = Object.create(_abstract_processor2.default.prototype);
+HbsProcessor.prototype = Object.create(_abstract_processor["default"].prototype);
 HbsProcessor.prototype.constructor = HbsProcessor;
-
 HbsProcessor.prototype.defaultPattern = "**/*.hbs";
-HbsProcessor.prototype.Extractor = _extractor2.default;
+HbsProcessor.prototype.Extractor = _extractor["default"];
 
 HbsProcessor.prototype.checkContents = function (source, path) {
-  var extractor = new this.Extractor(this.preProcess(source), { path: path });
+  var extractor = new this.Extractor(this.preProcess(source), {
+    path: path
+  });
   extractor.forEach(function (key, value, context) {
     this.translations.set(key, value, context);
     this.translationCount++;
@@ -45,13 +37,16 @@ HbsProcessor.prototype.checkContents = function (source, path) {
 };
 
 HbsProcessor.prototype.sourceFor = function (file) {
-  return _fs2.default.readFileSync(file);
+  return _fs["default"].readFileSync(file);
 };
 
 HbsProcessor.prototype.preProcess = function (source) {
-  var ast = _handlebars2.default.parse(source.toString());
-  _pre_processor2.default.process(ast);
+  var ast = _handlebars["default"].parse(source.toString());
+
+  _pre_processor["default"].process(ast);
+
   return ast;
 };
 
-exports.default = HbsProcessor;
+var _default = HbsProcessor;
+exports["default"] = _default;

--- a/dist/lib/main.js
+++ b/dist/lib/main.js
@@ -1,22 +1,20 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports["default"] = void 0;
 
-var _pre_processor = require('./pre_processor');
+var _pre_processor = _interopRequireDefault(require("./pre_processor"));
 
-var _pre_processor2 = _interopRequireDefault(_pre_processor);
+var _hbs_processor = _interopRequireDefault(require("./hbs_processor"));
 
-var _hbs_processor = require('./hbs_processor');
-
-var _hbs_processor2 = _interopRequireDefault(_hbs_processor);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 var registerPlugin = function registerPlugin(i18nliner) {
-  i18nliner.processors.HbsProcessor = _hbs_processor2.default;
+  i18nliner.processors.HbsProcessor = _hbs_processor["default"];
 };
-registerPlugin.PreProcessor = _pre_processor2.default;
 
-exports.default = registerPlugin;
+registerPlugin.PreProcessor = _pre_processor["default"];
+var _default = registerPlugin;
+exports["default"] = _default;

--- a/dist/lib/t_call.js
+++ b/dist/lib/t_call.js
@@ -3,12 +3,11 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports["default"] = void 0;
 
-var _translate_call = require("i18nliner/dist/lib/extractors/translate_call");
+var _translate_call = _interopRequireDefault(require("i18nliner/dist/lib/extractors/translate_call"));
 
-var _translate_call2 = _interopRequireDefault(_translate_call);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 /*
  * hbs-capable version of TranslateCall
@@ -20,22 +19,25 @@ function TCall(sexpr) {
       method = sexpr.string,
       args = this.processArguments(sexpr);
 
-  _translate_call2.default.call(this, line, method, args);
+  _translate_call["default"].call(this, line, method, args);
 }
 
-TCall.prototype = Object.create(_translate_call2.default.prototype);
+TCall.prototype = Object.create(_translate_call["default"].prototype);
 TCall.prototype.constructor = TCall;
 
 TCall.prototype.processArguments = function (sexpr) {
   var args = sexpr.params,
       hash = sexpr.hash,
       result = [];
+
   for (var i = 0, len = args.length; i < len; i++) {
     result.push(this.evaluateExpression(args[i]));
   }
+
   if (hash) {
     result.push(this.processHash(hash.pairs));
   }
+
   return result;
 };
 
@@ -49,9 +51,13 @@ TCall.prototype.processHash = function (pairs) {
   var result = {},
       len = pairs.length,
       i;
+
   for (i = 0; i < len; i++) {
     result[pairs[i][0]] = this.UNSUPPORTED_EXPRESSION;
-  }return result;
+  }
+
+  return result;
 };
 
-exports.default = TCall;
+var _default = TCall;
+exports["default"] = _default;

--- a/dist/lib/visitor.js
+++ b/dist/lib/visitor.js
@@ -1,8 +1,10 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports["default"] = void 0;
+
 /*
  * simple handlebars AST traverser
  *
@@ -10,42 +12,46 @@ Object.defineProperty(exports, "__esModule", {
  * things as needed to make it useful (e.g. override processSexpr if you
  * want to know when particular helpers are called)
  */
-
 var Visitor = {
   process: function process(ast) {
     var statements = ast.statements,
         statementsLen = statements.length,
         i;
+
     for (i = 0; i < statementsLen; i++) {
       this.processExpression(statements[i]);
     }
   },
-
   processExpression: function processExpression(statement) {
     switch (statement.type) {
       case 'block':
         this.process(statement.program);
         if (statement.inverse) this.process(statement.inverse);
         break;
+
       case 'mustache':
         this.processSexpr(statement.sexpr);
         break;
+
       case 'sexpr':
         this.processSexpr(statement);
         break;
     }
   },
-
   processSexpr: function processSexpr(sexpr) {
     var i, len, items;
+
     if (sexpr.type === 'sexpr') {
       this.processExpression(sexpr.id);
       items = sexpr.params;
+
       for (i = 0, len = items.length; i < len; i++) {
         this.processExpression(items[i]);
       }
+
       if (sexpr.hash) {
         items = sexpr.hash.pairs;
+
         for (i = 0, len = items.length; i < len; i++) {
           this.processExpression(items[i][1]);
         }
@@ -53,5 +59,5 @@ var Visitor = {
     }
   }
 };
-
-exports.default = Visitor;
+var _default = Visitor;
+exports["default"] = _default;

--- a/lib/pre_processor.js
+++ b/lib/pre_processor.js
@@ -1,7 +1,7 @@
 /* global window */
 
 import Handlebars from "handlebars";
-import {jsdom} from "jsdom";
+import { JSDOM } from "jsdom";
 import CallHelpers from "i18nliner/dist/lib/call_helpers";
 import Errors from "./errors";
 
@@ -9,7 +9,7 @@ var dom = (function(){
   if (typeof window !== 'undefined') {
     return window.document;
   } else {
-    return jsdom().defaultView.document;
+    return (new JSDOM('')).window.document;
   }
 })();
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,22 @@
 {
-  "name": "i18nliner-handlebars",
+  "name": "@instructure/i18nliner-handlebars",
   "description": "handlebars i18n made simple",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "contributors": [
     {
       "name": "Jon Jensen"
     },
     {
       "name": "Stanley Stuart"
+    },
+    {
+      "name": "Ahmad Amireh"
     }
   ],
-  "homepage": "https://github.com/fivetanley/i18nliner-handlebars",
+  "homepage": "https://github.com/instructure/i18nliner-handlebars",
   "repository": {
     "type": "git",
-    "url": "http://github.com/fivetanley/i18nliner-handlebars.git"
+    "url": "http://github.com/instructure/i18nliner-handlebars.git"
   },
   "main": "./dist/lib/main",
   "devDependencies": {
@@ -36,7 +39,7 @@
     "test": "grunt eslint && grunt test && mocha tmp/test"
   },
   "peerDependencies": {
-    "handlebars": ">=1.3 <3",
+    "handlebars": "~1.3.0",
     "i18nliner": "~0.2.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@instructure/i18nliner-handlebars",
   "description": "handlebars i18n made simple",
   "version": "1.0.0",
+  "license": "MIT",
   "contributors": [
     {
       "name": "Jon Jensen"
@@ -20,29 +21,27 @@
   },
   "main": "./dist/lib/main",
   "devDependencies": {
-    "babel-preset-latest": "~6.22.0",
-    "chai": "~3.5.0",
-    "eslint": "~3.16.1",
-    "grunt": "~1.0.1",
-    "grunt-babel": "~6.0.0",
-    "grunt-contrib-clean": "~1.0.0",
-    "grunt-contrib-copy": "~1.0.0",
-    "gruntify-eslint": "~3.1.0",
+    "@babel/cli": "^7.12.7",
+    "@babel/core": "^7.12.7",
+    "@babel/preset-env": "^7.12.7",
+    "chai": "^3.5.0",
+    "eslint": "^7.14.0",
     "handlebars": "~1.3.0",
     "i18nliner": "~0.2.0",
-    "jsdom": "~8.5.0",
-    "matchdep": "~1.0.1",
-    "mocha": "~3.2.0",
-    "sinon": "~1.17.7"
+    "jsdom": "^16.4.0",
+    "mocha": "^8.2.1",
+    "sinon": "^9.2.1"
   },
   "scripts": {
-    "test": "grunt eslint && grunt test && mocha tmp/test"
+    "build": "babel -d dist/lib lib",
+    "clean": "rm -rf dist tmp/test",
+    "lint": "eslint lib test",
+    "test": "babel -d tmp/test test && babel -d tmp/lib lib && mocha tmp/test"
   },
   "peerDependencies": {
     "handlebars": "~1.3.0",
-    "i18nliner": "~0.2.0"
+    "i18nliner": "~0.2.0",
+    "jsdom": "^14, ^15, ^16"
   },
-  "dependencies": {
-    "jsdom": "~8.5.0"
-  }
+  "dependencies": {}
 }

--- a/test/pre_processor_test.js
+++ b/test/pre_processor_test.js
@@ -9,7 +9,7 @@ import PreProcessor from "../lib/pre_processor";
 describe("PreProcessor", function() {
   before(function() {
     var StringNode = Handlebars.AST.StringNode;
-    this.inferKey = sinon.stub(PreProcessor, "inferKey", function() {
+    this.inferKey = sinon.stub(PreProcessor, "inferKey").callsFake(function() {
       return new StringNode("key");
     });
   });


### PR DESCRIPTION
if you want to test this in canvas-lms, apply the following patch then verify you can rebuild your assets through `rake canvas:compile_assets`:

```diff
diff --git a/gems/canvas_i18nliner/package.json b/gems/canvas_i18nliner/package.json
index d15bae9a81..e4ef289a75 100644
--- a/gems/canvas_i18nliner/package.json
+++ b/gems/canvas_i18nliner/package.json
@@ -9,7 +9,7 @@
     "glob": "^7.0.3",
     "handlebars": "1.3.0",
     "i18nliner": "instructure/i18nliner-js#babel7",
-    "i18nliner-handlebars": "^0.2.2",
+    "i18nliner-handlebars": "instructure/i18nliner-handlebars#7dfb22bd5692156eb823737e9124b72b7cfb5407",
     "minimist": "^1.1.0",
     "mkdirp": "^0.5.1"
   },
```